### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.1 (2022-02-19)
+
+### Fixes
+- Corrects default environment variables in Dockerfile
+
+
 ## 1.0.0 (2022-02-19)
 
 ### Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,11 @@ EXPOSE 8080
 
 ENTRYPOINT [ \
     "java", \
-    "-Dmysql_host=${STREAMA_MYSQL_HOST:-localhost}", \
-    "-Dmysql_port=${STREAMA_MYSQL_PORT:-3306}", \
-    "-Dmysql_db=${STREAMA_MYSQL_DB:-streama}", \
-    "-Dmysql_user=${STREAMA_MYSQL_USER:-streama}", \
-    "-Dmysql_password=${STREAMA_MYSQL_PASSWORD:-streama}", \
+    "-Dmysql_host=${STREAMA_MYSQL_HOST:localhost}", \
+    "-Dmysql_port=${STREAMA_MYSQL_PORT:3306}", \
+    "-Dmysql_db=${STREAMA_MYSQL_DB:streama}", \
+    "-Dmysql_user=${STREAMA_MYSQL_USER:streama}", \
+    "-Dmysql_password=${STREAMA_MYSQL_PASSWORD:streama}", \
     "-jar", \
     "/app/streama.jar" \
 ]


### PR DESCRIPTION
# Short description

Release 1.0.1


# Changes

- Corrects default environment variables in Dockerfile


# Tests

Docker-compose was launched with only `STREAMA_MYSQL_HOST` defined as environment variable
